### PR TITLE
skip monitoring create/kill jobs

### DIFF
--- a/cmd/kill.go
+++ b/cmd/kill.go
@@ -30,6 +30,7 @@ func init() {
 	killJobCmd.Flags().StringVarP(env, "environment", "e", "", "Aurora Environment")
 	killJobCmd.Flags().StringVarP(role, "role", "r", "", "Aurora Role")
 	killJobCmd.Flags().StringVarP(name, "name", "n", "", "Aurora Name")
+	killJobCmd.Flags().BoolVarP(&monitor, "monitor", "m", false, "monitor the result after sending the command")
 	killJobCmd.MarkFlagRequired("environment")
 	killJobCmd.MarkFlagRequired("role")
 	killJobCmd.MarkFlagRequired("name")
@@ -57,8 +58,9 @@ func killJob(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalln(err)
 	}
-
-	if ok, err := client.MonitorInstances(job.JobKey(), 0, 5, 50); !ok || err != nil {
-		log.Fatalln("Unable to kill all instances of job")
+	if monitor {
+		if ok, err := client.MonitorInstances(job.JobKey(), 0, 5, 50); !ok || err != nil {
+			log.Fatalln("Unable to kill all instances of job")
+		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,7 @@ var count int64
 var filename string
 var message = new(string)
 var updateID string
+var monitor bool
 var log = logrus.New()
 
 const australisVer = "v0.22.0"


### PR DESCRIPTION
Issue: Current Australis always check the status of a job after creating/killing it. Sometime it is not necessary to do so. For example, if you want to submit a bunch of jobs in a short time, you have to wait for the first completes and then move to the second one.

I added the following flag to create & kill job command.
```-m, --monitor   monitor the result after sending the command```

By default, it is true so it does not change the current behavior of Australis. If we set `-m false`, we don't need to monitor the outcome.