### PR TITLE
Increase backoff steps and reduce factor

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -146,9 +146,9 @@ func connect(cmd *cobra.Command, args []string) {
 		realis.ThriftJSON(),
 		realis.Timeout(timeout),
 		realis.BackOff(realis.Backoff{
-			Steps:    2,
+			Steps:    6,
 			Duration: 10 * time.Second,
-			Factor:   2.0,
+			Factor:   1.5,
 			Jitter:   0.1,
 		}),
 		realis.SetLogger(log)}


### PR DESCRIPTION
The new retry times would be (approximately):
10, 15, 22.5, 33, 50, 75 which sum to about 207 seconds. This is to overcome leader registration times with Mesos that we have seen around 180 seconds. 