### PR TITLE
API to get master nodes for mesos and aurora

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -98,7 +98,7 @@ func init() {
 	})
 
 	/* Fetch Master nodes/Leader */
-	masterCmd.Flags().String("zkPath", "/aurora/scheduler", "Zookeeper node path to get master nodes/leaders")
+	masterCmd.Flags().String("zkPath", "/aurora/scheduler", "Zookeeper node path to get master nodes/leader")
 
 	fetchCmd.AddCommand(masterCmd)
 
@@ -114,7 +114,7 @@ func init() {
 		help(cmd, s)
 	})
 
-	mesosMasterCmd.Flags().String("zkPath", "/mesos", "Zookeeper node path to get mesos master nodes/leaders")
+	mesosMasterCmd.Flags().String("zkPath", "/mesos", "Zookeeper node path to get mesos master nodes/leader")
 	mesosCmd.AddCommand(mesosMasterCmd)
 
 	// Hijack help function to hide unnecessary global flags
@@ -428,8 +428,10 @@ func fetchMaster(cmd *cobra.Command, args []string) {
 	if toJson {
 		fmt.Println(internal.ToJSON(masterMap))
 	} else {
-		for key, mesosMasterNodes := range masterMap {
-			fmt.Println(key + "=" + mesosMasterNodes)
+		for key, masterNodes := range masterMap {
+			for _, masterNode := range masterNodes {
+				fmt.Println(key + "=" + masterNode)
+			}
 		}
 	}
 }
@@ -440,9 +442,6 @@ func fetchMesosMaster(cmd *cobra.Command, args []string) {
 		if err != nil || mesosAgentFlags.Master == "" {
 			log.Debugf("unable to fetch Mesos master nodes via local Mesos agent: %v", err)
 			args = append(args, "localhost")
-		} else if mesosAgentFlags.hasMaster {
-			fmt.Println(mesosAgentFlags.Master)
-			return
 		} else {
 			args = append(args, strings.Split(mesosAgentFlags.Master, ",")...)
 		}
@@ -458,7 +457,9 @@ func fetchMesosMaster(cmd *cobra.Command, args []string) {
 		fmt.Println(internal.ToJSON(mesosMasterMap))
 	} else {
 		for key, mesosMasterNodes := range mesosMasterMap {
-			fmt.Println(key + "=" + mesosMasterNodes)
+			for _, mesosMasterNode := range mesosMasterNodes {
+				fmt.Println(key + "=" + mesosMasterNode)
+			}
 		}
 	}
 }

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -97,6 +97,38 @@ func init() {
 		help(cmd, s)
 	})
 
+	/* Fetch Master nodes/Leader */
+	masterCmd.Flags().String("zkPath", "/aurora/scheduler", "Zookeeper node path to get master nodes/leaders")
+
+	fetchCmd.AddCommand(masterCmd)
+
+	// Hijack help function to hide unnecessary global flags
+	masterCmd.SetHelpFunc(func(cmd *cobra.Command, s []string) {
+		if cmd.HasInheritedFlags() {
+			cmd.InheritedFlags().VisitAll(func(f *pflag.Flag) {
+				if f.Name != "logLevel" {
+					f.Hidden = true
+				}
+			})
+		}
+		help(cmd, s)
+	})
+
+	mesosMasterCmd.Flags().String("zkPath", "/mesos", "Zookeeper node path to get mesos master nodes/leaders")
+	mesosCmd.AddCommand(mesosMasterCmd)
+
+	// Hijack help function to hide unnecessary global flags
+	mesosMasterCmd.SetHelpFunc(func(cmd *cobra.Command, s []string) {
+		if cmd.HasInheritedFlags() {
+			cmd.InheritedFlags().VisitAll(func(f *pflag.Flag) {
+				if f.Name != "logLevel" {
+					f.Hidden = true
+				}
+			})
+		}
+		help(cmd, s)
+	})
+
 	// Fetch jobs
 	fetchJobsCmd.Flags().StringVarP(role, "role", "r", "", "Aurora Role")
 	fetchCmd.AddCommand(fetchJobsCmd)
@@ -180,6 +212,18 @@ Pass Zookeeper nodes separated by a space as an argument to this command.`,
 	Run: fetchLeader,
 }
 
+var masterCmd = &cobra.Command{
+	Use:               "master [zkNode0 zkNode1  ...zkNodeN]",
+	PersistentPreRun:  func(cmd *cobra.Command, args []string) {}, // We don't need a realis client for this cmd
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {}, // We don't need a realis client for this cmd
+	PreRun:            setConfig,
+	Args:              cobra.MinimumNArgs(1),
+	Short:             "Fetch current Aurora master nodes/leader given Zookeeper nodes. ",
+	Long: `Gets the current aurora master nodes/leader using information from Zookeeper path.
+Pass Zookeeper nodes separated by a space as an argument to this command.`,
+	Run: fetchMaster,
+}
+
 var mesosCmd = &cobra.Command{
 	Use:    "mesos",
 	PreRun: setConfig,
@@ -196,6 +240,18 @@ var mesosLeaderCmd = &cobra.Command{
 Pass Zookeeper nodes separated by a space as an argument to this command. If no nodes are provided, 
 it fetches leader from local Mesos agent or Zookeeper`,
 	Run: fetchMesosLeader,
+}
+
+var mesosMasterCmd = &cobra.Command{
+	Use:               "master [zkNode0 zkNode1 ...zkNodeN]",
+	PersistentPreRun:  func(cmd *cobra.Command, args []string) {}, // We don't need a realis client for this cmd
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {}, // We don't need a realis client for this cmd
+	PreRun:            setConfig,
+	Short:             "Fetch current Mesos-master nodes/leader given Zookeeper nodes.",
+	Long: `Gets the current Mesos-master instances using information from Zookeeper path.
+Pass Zookeeper nodes separated by a space as an argument to this command. If no nodes are provided, 
+it fetches Mesos-master nodes/leader from local Mesos agent or Zookeeper`,
+	Run: fetchMesosMaster,
 }
 
 var fetchJobsCmd = &cobra.Command{
@@ -354,6 +410,57 @@ func fetchMesosLeader(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Println(url)
+}
+
+func fetchMaster(cmd *cobra.Command, args []string) {
+	log.Infof("Fetching master nodes from %v \n", args)
+
+	if len(args) < 1 {
+		log.Fatalln("At least one Zookeeper node address must be passed in.")
+	}
+
+	masterMap, err := realis.MasterNodesFromZKOpts(realis.ZKEndpoints(args...), realis.ZKPath(cmd.Flag("zkPath").Value.String()))
+
+	if err != nil {
+		log.Fatalf("error: %+v\n", err)
+	}
+
+	if toJson {
+		fmt.Println(internal.ToJSON(masterMap))
+	} else {
+		for key, mesosMasterNodes := range masterMap {
+			fmt.Println(key + "=" + mesosMasterNodes)
+		}
+	}
+}
+
+func fetchMesosMaster(cmd *cobra.Command, args []string) {
+	if len(args) < 1 {
+		mesosAgentFlags, err := fetchMasterFromAgent(localAgentStateURL)
+		if err != nil || mesosAgentFlags.Master == "" {
+			log.Debugf("unable to fetch Mesos master nodes via local Mesos agent: %v", err)
+			args = append(args, "localhost")
+		} else if mesosAgentFlags.hasMaster {
+			fmt.Println(mesosAgentFlags.Master)
+			return
+		} else {
+			args = append(args, strings.Split(mesosAgentFlags.Master, ",")...)
+		}
+	}
+	log.Infof("Fetching Mesos-master nodes from Zookeeper node(s): %v \n", args)
+
+	mesosMasterMap, err := realis.MesosMasterNodesFromZKOpts(realis.ZKEndpoints(args...), realis.ZKPath(cmd.Flag("zkPath").Value.String()))
+
+	if err != nil {
+		log.Fatalf("error: %+v\n", err)
+	}
+	if toJson {
+		fmt.Println(internal.ToJSON(mesosMasterMap))
+	} else {
+		for key, mesosMasterNodes := range mesosMasterMap {
+			fmt.Println(key + "=" + mesosMasterNodes)
+		}
+	}
 }
 
 func fetchMasterFromAgent(url string) (mesosAgentFlags mesosAgentFlags, err error) {

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,7 @@ module github.com/aurora-scheduler/australis
 go 1.15
 
 require (
-	github.com/andygrunwald/megos v0.0.0-20210622170559-e9ff1cac83c5
-	github.com/aurora-scheduler/gorealis/v2 v2.28.0
-	github.com/gizak/termui/v3 v3.1.0
+	github.com/aurora-scheduler/gorealis/v2 v2.29.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0


### PR DESCRIPTION
**Description:**
2 new APIs to fetch aurora master nodes and mesos master nodes

**Usage:**
1. Fetch aurora master nodes:
for example:  
$ ./australis fetch master 10.180.52.93 10.180.52.175 --toJSON
INFO[0000] Fetching master nodes from [10.180.52.93 10.180.52.175]  
{"leader":"gpzkmmas2-4.gpf-prod.us-central1.gcp.dev.paypalinc.com","masterNodes":"gpzkmmas2-5.gpf-prod.us-central1.gcp.dev.paypalinc.com,gpzkmmas2-6.gpf-prod.us-central1.gcp.dev.paypalinc.com,gpzkmmas2-4.gpf-prod.us-central1.gcp.dev.paypalinc.com"}

2. Fetch mesos master nodes:
for example:   
$ ./australis fetch mesos master 10.180.52.93 10.180.52.175
INFO[0000] Fetching Mesos-master nodes from Zookeeper node(s): [10.180.52.93 10.180.52.175]  
{"leader":"gpzkmmas2-5.gpf-prod.us-central1.gcp.dev.paypalinc.com","masterNodes":"gpzkmmas2-5.gpf-prod.us-central1.gcp.dev.paypalinc.com,gpzkmmas2-6.gpf-prod.us-central1.gcp.dev.paypalinc.com,gpzkmmas2-4.gpf-prod.us-central1.gcp.dev.paypalinc.com"}

**Notes:**
This PR depends on another PR on gorealis: https://github.com/aurora-scheduler/gorealis/pull/20